### PR TITLE
Adding the SMOG index

### DIFF
--- a/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
+++ b/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
@@ -1,0 +1,28 @@
+package org.voyanttools.trombone.model;
+
+import org.voyanttools.trombone.tool.util.TextParser;
+
+public class SMOGIndex extends ReadabilityIndex {
+
+    protected double smogIndex;
+
+    public SMOGIndex(int documentIndex, String documentId, String textToParse) {
+        super(documentIndex, documentId, textToParse);
+
+        smogIndex = calculateIndex(text);
+    }
+
+    /*
+    Mc Laughlin, G. Harry. “SMOG Grading-a New Readability Formula.” Journal of Reading 12, no. 8 (1969): 639–46. http://www.jstor.org/stable/40011226.
+     */
+    @Override
+    protected double calculateIndex(TextParser text) {
+        double a = (double) text.getNbrOfWordsWithMoreThanTwoSyllables() * 30 / (double) text.getNbrOfSentences();
+
+        return 1.043 * Math.sqrt(a) + 3.1291;
+    }
+
+    public double getSMOGIndex() {
+        return smogIndex;
+    }
+}

--- a/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
+++ b/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
@@ -17,9 +17,9 @@ public class SMOGIndex extends ReadabilityIndex {
      */
     @Override
     protected double calculateIndex(TextParser text) {
-        double a = (double) text.getNbrOfWordsWithMoreThanTwoSyllables() * 30 / (double) text.getNbrOfSentences();
+        double polysyllablesWordsPerSentence = (double) text.getWordsWithMoreThanTwoSyllablesCount() / text.getSentencesCount();
 
-        return 1.043 * Math.sqrt(a) + 3.1291;
+        return 1.043 * Math.sqrt(30 * polysyllablesWordsPerSentence) + 3.1291;
     }
 
     public double getSMOGIndex() {

--- a/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
+++ b/src/main/java/org/voyanttools/trombone/model/SMOGIndex.java
@@ -19,7 +19,13 @@ public class SMOGIndex extends ReadabilityIndex {
     protected double calculateIndex(TextParser text) {
         double polysyllablesWordsPerSentence = (double) text.getWordsWithMoreThanTwoSyllablesCount() / text.getSentencesCount();
 
-        return 1.043 * Math.sqrt(30 * polysyllablesWordsPerSentence) + 3.1291;
+        double result = 1.043 * Math.sqrt(30 * polysyllablesWordsPerSentence) + 3.1291;
+
+        if (Double.isFinite(result))
+            return result;
+
+        // When the calculation fails (result is not a finite number)
+        return -999;
     }
 
     public double getSMOGIndex() {

--- a/src/main/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndex.java
+++ b/src/main/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndex.java
@@ -1,0 +1,38 @@
+package org.voyanttools.trombone.tool.corpus;
+
+import org.voyanttools.trombone.lucene.CorpusMapper;
+import org.voyanttools.trombone.model.Corpus;
+import org.voyanttools.trombone.model.SMOGIndex;
+import org.voyanttools.trombone.storage.Storage;
+import org.voyanttools.trombone.util.FlexibleParameters;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DocumentSMOGIndex extends AbstractCorpusTool {
+
+    private List<SMOGIndex> smogIndexes;
+
+    public DocumentSMOGIndex(Storage storage, FlexibleParameters parameters) {
+        super(storage, parameters);
+
+        smogIndexes = new ArrayList<>();
+    }
+
+    @Override
+    public void run(CorpusMapper corpusMapper) throws IOException {
+        Corpus corpus = corpusMapper.getCorpus();
+
+        for (String documentId : corpus.getDocumentIds()) {
+            int documentIndex = corpus.getDocumentPosition(documentId);
+            String text = corpus.getDocument(documentId).getDocumentString();
+
+            smogIndexes.add(new SMOGIndex(documentIndex, documentId, text));
+        }
+    }
+
+    public List<SMOGIndex> getSMOGIndexes() {
+        return smogIndexes;
+    }
+}

--- a/src/main/java/org/voyanttools/trombone/tool/util/TextParser.java
+++ b/src/main/java/org/voyanttools/trombone/tool/util/TextParser.java
@@ -68,8 +68,8 @@ public class TextParser {
     }
 
     private boolean hasMoreThanTwoSyllables(String word) {
-        // This regex method has been found here https://stackoverflow.com/a/46879336
-        String regex = "[aiouyéêèï]+e*|e(?!d$|ly).|[td]ed|le$";
+        // This regex method has been inspired from here: https://stackoverflow.com/a/46879336
+        String regex = "[aâàáäiîìíïoôòóöuûùúüyêèéë]+e*|e(?!d$|ly).|[td]ed|le$";
         Matcher matcher = Pattern.compile(regex).matcher(word);
 
         int count = 0;
@@ -79,7 +79,7 @@ public class TextParser {
         }
 
         // Cover cases where the a "y" is between 2 vowels. E.g. "payable" has 3 syllables, but count as 2 with the above logic.
-        regex = "[aioueéêèï]y[aioueéêèï][^$]";
+        regex = "[aâàáäiîìíïoôòóöuûùúüyeêèéë]y[aâàáäiîìíïoôòóöuûùúüyeêèéë][^$]";
         matcher = Pattern.compile(regex).matcher(word);
         while (matcher.find()) {
             count++;

--- a/src/test/java/org/voyanttools/trombone/model/SMOGIndexTest.java
+++ b/src/test/java/org/voyanttools/trombone/model/SMOGIndexTest.java
@@ -1,0 +1,22 @@
+package org.voyanttools.trombone.model;
+
+import org.junit.Test;
+
+public class SMOGIndexTest {
+
+    public static final String TEXT = "The rule of rhythm in prose is not so intricate. Here, too, we write in groups, or phrases, as I prefer to call them, for the prose phrase is greatly longer and is much more nonchalantly uttered than the group in verse; so that not only is there a greater interval of continuous sound between the pauses, but, for that very reason, word is linked more readily to word by a more summary enunciation. Still, the phrase is the strict analogue of the group, and successive phrases, like successive groups, must differ openly in length and rhythm. The rule of scansion in verse is to suggest no measure but the one in hand; in prose, to suggest no measure at all. Prose must be rhythmical, and it may be as much so as you will; but it must not be metrical. It may be anything, but it must not be verse.";
+
+    private static final int A_DOCUMENT_INDEX = 0;
+    private static final String A_DOCUMENT_ID = "A_DOCUMENT_ID";
+
+    public static final double EXPECTED_SMOG_INDEX = 11.855464076750408;
+
+    @Test
+    public void test() {
+        SMOGIndex smogIndex = new SMOGIndex(A_DOCUMENT_INDEX, A_DOCUMENT_ID, TEXT);
+
+        assert smogIndex.docIndex == A_DOCUMENT_INDEX;
+        assert smogIndex.docId.equals(A_DOCUMENT_ID);
+        assert smogIndex.getSMOGIndex() == EXPECTED_SMOG_INDEX;
+    }
+}

--- a/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentFOGIndexTest.java
+++ b/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentFOGIndexTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class DocumentFOGIndexTest {
 
     private static final String FILE_PATH_FR = "udhr/udhr-fr.txt";
-    private static final double EXPECTED_FR_FOG_INDEX = 15.627728400992874;
+    private static final double EXPECTED_FR_FOG_INDEX = 15.65228334267489;
 
     private static final String FILE_PATH_EN = "udhr/udhr-en.txt";
     private static final double EXPECTED_EN_FOG_INDEX = 11.036356849570737;

--- a/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
+++ b/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class DocumentSMOGIndexTest {
 
     private static final String FILE_PATH_FR = "udhr/udhr-fr.txt";
-    private static final double EXPECTED_FR_SMOG_INDEX = 12.96994396234918;
+    private static final double EXPECTED_FR_SMOG_INDEX = 14.239780114587749;
 
     private static final String FILE_PATH_EN = "udhr/udhr-en.txt";
     private static final double EXPECTED_EN_SMOG_INDEX = 10.227310004160055;

--- a/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
+++ b/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
@@ -1,0 +1,46 @@
+package org.voyanttools.trombone.tool.corpus;
+
+import org.junit.Test;
+import org.voyanttools.trombone.model.SMOGIndex;
+import org.voyanttools.trombone.model.SMOGIndexTest;
+import org.voyanttools.trombone.storage.Storage;
+import org.voyanttools.trombone.util.FlexibleParameters;
+import org.voyanttools.trombone.util.TestHelper;
+
+import java.io.IOException;
+import java.util.List;
+
+
+public class DocumentSMOGIndexTest {
+
+    private static final String FILE_PATH_FR = "udhr/udhr-fr.txt";
+    private static final double EXPECTED_FR_SMOG_INDEX = 12.96994396234918;
+
+    private static final String FILE_PATH_EN = "udhr/udhr-en.txt";
+    private static final double EXPECTED_EN_SMOG_INDEX = 10.227310004160055;
+
+    @Test
+    public void test() throws IOException {
+        for (Storage storage : TestHelper.getDefaultTestStorages()) {
+            System.out.println("Testing with "+storage.getClass().getSimpleName()+": "+storage.getLuceneManager().getClass().getSimpleName());
+
+            testWithGivenParameters(storage, new FlexibleParameters(new String[]{"string="+SMOGIndexTest.TEXT}), SMOGIndexTest.EXPECTED_SMOG_INDEX);
+            testWithGivenParameters(storage, new FlexibleParameters(new String[]{"file="+TestHelper.getResource(FILE_PATH_FR)}), EXPECTED_FR_SMOG_INDEX);
+            testWithGivenParameters(storage, new FlexibleParameters(new String[]{"file="+TestHelper.getResource(FILE_PATH_EN)}), EXPECTED_EN_SMOG_INDEX);
+        }
+    }
+
+    private void testWithGivenParameters(Storage storage, FlexibleParameters parameters, double expectedSMOGIndex) throws IOException {
+        CorpusCreator creator = new CorpusCreator(storage, parameters);
+        creator.run();
+
+        DocumentSMOGIndex documentSMOGIndex = new DocumentSMOGIndex(storage, parameters);
+        documentSMOGIndex.run();
+
+        List<SMOGIndex> smogIndexes = documentSMOGIndex.getSMOGIndexes();
+
+        for (SMOGIndex smogIndex : smogIndexes) {
+            assert smogIndex.getSMOGIndex() == expectedSMOGIndex;
+        }
+    }
+}

--- a/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
+++ b/src/test/java/org/voyanttools/trombone/tool/corpus/DocumentSMOGIndexTest.java
@@ -14,7 +14,7 @@ import java.util.List;
 public class DocumentSMOGIndexTest {
 
     private static final String FILE_PATH_FR = "udhr/udhr-fr.txt";
-    private static final double EXPECTED_FR_SMOG_INDEX = 14.239780114587749;
+    private static final double EXPECTED_FR_SMOG_INDEX = 14.255732283771263;
 
     private static final String FILE_PATH_EN = "udhr/udhr-en.txt";
     private static final double EXPECTED_EN_SMOG_INDEX = 10.227310004160055;


### PR DESCRIPTION
Adding the SMOG Index (https://en.wikipedia.org/wiki/SMOG).

The Syllables Counter has also been improved by supporting more vowels with accents to improve support for other western European languages (but it does not change anything for the English corpus).

