### PR TITLE
Stop filtering on minRawFreq before distribution statistics are calcu…

### DIFF
--- a/src/main/java/org/voyanttools/trombone/tool/corpus/CorpusTerms.java
+++ b/src/main/java/org/voyanttools/trombone/tool/corpus/CorpusTerms.java
@@ -138,9 +138,7 @@ public class CorpusTerms extends AbstractTerms implements Iterable<CorpusTerm> {
 								rawFreqsMap.put(term, new HashMap<Integer, Integer>());
 							}
 							int rawF = (int) termsEnum.totalTermFreq();
-							if (rawF>minRawFreq) {
-								rawFreqsMap.get(term).put(corpusMapper.getDocumentPositionFromLuceneId(doc), rawF);
-							}
+							rawFreqsMap.get(term).put(corpusMapper.getDocumentPositionFromLuceneId(doc), rawF);
 						}
 						bytesRef = termsEnum.next();
 					}


### PR DESCRIPTION
resolves #38,

When runAllTermsWithDistributionsDocumentTermVectors runs it filters on minRawFreq twice. At first it removes all instances of the word that don't hit the minRawFreq at the document level. Then it calculates the statistics. Finally it removes all words that don't hit the minRawFreq at the corpus level.

I fundamentally believe this behavior is confusing as words are not filtered at the document level if runAllTermsWithoutDistributions is run. Resulting in conflicting and confusing numbers.

The fix I propose is simple. We just remove the document level filter in runAllTermsWithDistributionsDocumentTermVectors, and leave everything else as is.